### PR TITLE
Phrase sync workflow

### DIFF
--- a/.github/workflows/phrase_sync.yml
+++ b/.github/workflows/phrase_sync.yml
@@ -20,13 +20,13 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: phrase push
-        uses: mindbox-moscow/github-actions/localization/phrase_push@master
+        uses: mindbox-moscow/github-actions/localization/phrase-push@master
         with:
           phraseAppToken: ${{ secrets.phraseAppToken }}
           slackWebhookUrl: ${{ secrets.slackWebhookUrl }}
 
       - name: phrase pull
-        uses: mindbox-moscow/github-actions/localization/phrase_pull@master
+        uses: mindbox-moscow/github-actions/localization/phrase-pull@master
         with:
           gitHubToken: ${{ secrets.gitHubToken }}
           phraseAppToken: ${{ secrets.phraseAppToken }}

--- a/.github/workflows/phrase_sync.yml
+++ b/.github/workflows/phrase_sync.yml
@@ -1,0 +1,33 @@
+name: Phrase sync
+description: Pushes local localization keys to PhraseApp, then pulls new localization keys from PhraseApp.
+on:
+  workflow_call:
+    secrets:
+      phraseAppToken:
+        description: 'Token to access PhraseApp'
+        required: true
+      slackWebhookUrl:
+        description: 'Slack webhook url to send notifications'
+        required: true
+      gitHubToken:
+        description: 'GitHub token used to create PRs'
+        required: true
+jobs:
+  phrase-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: phrase push
+        uses: mindbox-moscow/gha-phrase-integration@master
+        with:
+          phraseAppToken: ${{ secrets.phraseAppToken }}
+          slackWebhookUrl: ${{ secrets.slackWebhookUrl }}
+
+      - name: phrase pull
+        uses: mindbox-moscow/gha-phrase-integration@master
+        with:
+          gitHubToken: ${{ secrets.frontend_gha_full_token }}
+          phraseAppToken: ${{ secrets.phrase_app_token }}

--- a/.github/workflows/phrase_sync.yml
+++ b/.github/workflows/phrase_sync.yml
@@ -20,13 +20,13 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: phrase push
-        uses: mindbox-moscow/gha-phrase-integration@master
+        uses: mindbox-moscow/github-actions/localization/phrase_push@master
         with:
           phraseAppToken: ${{ secrets.phraseAppToken }}
           slackWebhookUrl: ${{ secrets.slackWebhookUrl }}
 
       - name: phrase pull
-        uses: mindbox-moscow/gha-phrase-integration@master
+        uses: mindbox-moscow/github-actions/localization/phrase_pull@master
         with:
-          gitHubToken: ${{ secrets.frontend_gha_full_token }}
-          phraseAppToken: ${{ secrets.phrase_app_token }}
+          gitHubToken: ${{ secrets.gitHubToken }}
+          phraseAppToken: ${{ secrets.phraseAppToken }}

--- a/.github/workflows/phrase_sync.yml
+++ b/.github/workflows/phrase_sync.yml
@@ -1,5 +1,4 @@
 name: Phrase sync
-description: Pushes local localization keys to PhraseApp, then pulls new localization keys from PhraseApp.
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
Пушим и сразу пуллим, почти полная копия phrase_pull из фронтенда, только очищенная от всякого лишнего. Также часто подобный паттерн используется на беке, теперь копипастинг заменим на вызов этого воркфлоу. Фронтендеров тоже переведем на этот воркфлоу.