### PR TITLE
fix: fail e2e jobs if previous fails

### DIFF
--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-site
     timeout-minutes: ${{ inputs.e2e-timeout }}
-    if: ${{ !contains(github.ref, 'LocalizationPull') && !inputs.core_project }}
+    if: ${{ always() && !cancelled() && !contains(github.ref, 'LocalizationPull') && !inputs.core_project }}
     env:
       retries: ${{ inputs.retries }}
       CYPRESS_username: "${{ secrets.cypress_login }}"
@@ -225,6 +225,11 @@ jobs:
       template_folder: ${{ inputs.template_folder }}
 
     steps:
+      - uses: technote-space/workflow-conclusion-action@v3
+      - name: check fail
+        if: env.WORKFLOW_CONCLUSION == 'failure'
+        run: echo "previous steps are failed" && exit 1
+
       - name: Checkout the repository
         uses: actions/checkout@v2
 
@@ -356,7 +361,7 @@ jobs:
         project: ${{ fromJSON(needs.core-e2e-tests-matrix.outputs.matrix) }}
       max-parallel: 4
     timeout-minutes: ${{ inputs.e2e-timeout }}
-    if: ${{ !contains(github.ref, 'LocalizationPull') && inputs.core_project }}
+    if: ${{ always() && !cancelled() && !contains(github.ref, 'LocalizationPull') && inputs.core_project }}
     env:
       retries: ${{ inputs.retries }}
       CYPRESS_username: "${{ secrets.cypress_login }}"
@@ -367,6 +372,11 @@ jobs:
       template_folder: ${{ inputs.template_folder }}
 
     steps:
+      - uses: technote-space/workflow-conclusion-action@v3
+      - name: check fail
+        if: env.WORKFLOW_CONCLUSION == 'failure'
+        run: echo "previous steps are failed" && exit 1
+
       - name: Checkout the repository
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Запускаем джобы всегда(независимо от результатов предыдущих), если воркфлоу не заканселен.
При запуске проверяем зафейлился ли воркфлоу, если да, то убиваем джобу на старте.