### PR TITLE
feat: last commit hyperlink in changelog

### DIFF
--- a/generate-release-changelog/entrypoint.sh
+++ b/generate-release-changelog/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 
-git clone --quiet https://github.com/$REPO &> /dev/null
+repo_url="https://github.com/$REPO"
+git clone --quiet $repo_url &> /dev/null
 
 git config --global --add safe.directory /github/workspace
 
@@ -11,11 +12,15 @@ if [ "$tag" ]; then
 else
   changelog=$(git log --oneline --no-decorate)
 fi
+lastcommit=$(git log $tag..HEAD --pretty=format:"%H" | head)
+lastcommit_url="$repo_url/commit/$lastcommit"
+lastcommit_hyperlink="[View latest commit in Github]($lastcommit_url)"
 
 echo $changelog
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A' - }"
 changelog=" - ${changelog//$'\r'/'%0D'}"
+changelog=$lastcommit_hyperlink$'\n'$changelog
 
 echo "::set-output name=changelog::$changelog"


### PR DESCRIPTION
### Big Picture

Хотим, чтобы Октопус уведомлял о выкладке в пулл реквесты микрофронтов. Сейчас такие нотификации подключены только для [DirectCrm](https://octopus.mindbox.ru/app#/Spaces-1/projects/directcrm/deployments/process/steps?actionId=d6a7671b-06c4-4ad9-9186-366c46b436f3)

### Проблема

Для работы шага [Notify Github](https://octopus.mindbox.ru/app#/Spaces-1/library/steptemplates/ActionTemplates-602) нужно чтобы в release notes октопуса была ссылка на последний коммит релиза

<img width="940" alt="image" src="https://user-images.githubusercontent.com/31800676/180621596-4c39bf89-b182-438e-9402-e6673c33fa23.png">


### Решение

Вычисляем ссылку на последний коммит релиза через changelog
