### PR TITLE
Add hyperlike for commits view

### DIFF
--- a/generate-release-changelog/entrypoint.sh
+++ b/generate-release-changelog/entrypoint.sh
@@ -24,6 +24,9 @@ changelog=" - ${changelog//$'\r'/'%0D'}"
 lastcommit_url="$repo_url/commit/$lastcommit"
 lastcommit_hyperlink="[View latest commit in Github]($lastcommit_url)"
 
-changelog=$lastcommit_hyperlink$'<br/>'$changelog
+lastcommits_url="$repo_url/commits/$lastcommit"
+lastcommits_hyperlink="[View latest commits in Github]($lastcommits_url)"
+
+changelog=$lastcommit_hyperlink$'<br/>'$lastcommits_hyperlink$'<br/>'$changelog
 
 echo "::set-output name=changelog::$changelog"


### PR DESCRIPTION
Удобняшка для changelog'а в октопусе (всегда дописываю такое сам в урле).

Раньше было всегда вот так: `commit/{commit}`
Добавил вот такую: `commits/{commit}`

По этому URL удобнее смотреть, попали ли твои изменения в релиз.

PS: так должно взлететь? Есть лёгкая неуверенность, потому что в октопусе линк есть, а changelog'а - нет. Оно там случаем не первую строчку парсит только из output'а? Попробовал откопать, где это заюзано и как работает, но что-то не осилил.