### PR TITLE
Update frontend_e2e.yml

### DIFF
--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -87,6 +87,9 @@ on:
         description: 'A SA_TOKEN_DTLN_KUBE_CDP_STAGING_MICROFRONTENDS token passed from the caller workflow for new deploy'
         required: false
 
+env:
+  NODE_OPTIONS: --unhandled-rejections=strict
+
 jobs:
   prepare-site:
     runs-on: [self-hosted, frontend]
@@ -167,7 +170,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.npm_token }}
           MCF_STATIC_FOLDER: v2_static
-          NODE_OPTIONS: --unhandled-rejections=strict
 
       # needed for frontend discovery(build initial.js)
       - name: copy remoteEntry to v2_static folder

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -167,6 +167,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.npm_token }}
           MCF_STATIC_FOLDER: v2_static
+          NODE_OPTIONS: --unhandled-rejections=strict
 
       # needed for frontend discovery(build initial.js)
       - name: copy remoteEntry to v2_static folder


### PR DESCRIPTION
Добавляю флаг "unhandled-rejections=strict", чтобы не возникало сценариев как [тут](https://github.com/mindbox-moscow/frontend-customers/actions/runs/3943634742/jobs/6748770376#step:13:37). Скрипт падает, но без этого флага нода не убивается и шаг проходит.

[Проверка изменения](https://github.com/mindbox-moscow/frontend-customers/actions/runs/3959135672/jobs/6781685794)

### Вопрос
Есть ли еще шаги в которых такое может повторится? Тогда стоит поднять этот флаг выше.